### PR TITLE
Correct test

### DIFF
--- a/e2e/app.e2e-spec.ts
+++ b/e2e/app.e2e-spec.ts
@@ -10,7 +10,7 @@ describe('PIA Home page', () => {
   it('should display welcome message', done => {
     page.navigateTo();
     page.getButtonText()
-      .then(msg => expect(msg).toEqual('J\'accepte'))
+      .then(msg => expect(msg).toEqual('Commencer'))
       .then(done, done.fail);
   });
 });

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "zone.js": "^0.8.16"
   },
   "devDependencies": {
-    "@angular/cli": "^1.4.9",
+    "@angular/cli": "^1.4.9 < 1.5.5",
     "@angular/compiler-cli": "^4.4.3",
     "@angular/language-service": "^4.4.3",
     "@types/jasmine": "^2.5.53",


### PR DESCRIPTION
Start est traduit par "Commencer" et non "J'accepte" dans "fr.json".