### PR TITLE
Fixed version for save-svg-as-png between >1.3.0 and <1.4.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "normalize.css": "^7.0.0",
     "rollbar": "^2.2.8",
     "rxjs": "^5.1.0",
-    "save-svg-as-png": "^1.3.1",
+    "save-svg-as-png": ">1.3.0 <1.4.3",
     "tinymce": "^4.6.7",
     "zone.js": "^0.8.16"
   },


### PR DESCRIPTION
Fixes #252 