### PR TITLE
Added JSON summary export functionality

### DIFF
--- a/src/app/summary/summary.component.html
+++ b/src/app/summary/summary.component.html
@@ -15,6 +15,8 @@
     </button>
     <angular2csv [data]="csvContent" filename="plan_d-action" title="{{ 'summary.download_csv' | translate }}" class="btn hide-for-print" [options]="csvOptions"><i class="fa fa-2x fa-file-excel-o"></i></angular2csv>
     <button title="{{ 'summary.download_images' | translate }}" class="btn hide-for-print" (click)="downloadAllGraphsAsImages()"><i class="fa fa-2x fa-file-image-o"></i></button>
+
+    <button title="{{ 'summary.download_json' | translate }}" class="btn hide-for-print" (click)="downloadJSON()"><i class="fa fa-2x fa-file-code-o"></i></button>
   </div>
 
   <!-- Customize content filters -->

--- a/src/app/summary/summary.component.html
+++ b/src/app/summary/summary.component.html
@@ -15,7 +15,6 @@
     </button>
     <angular2csv [data]="csvContent" filename="plan_d-action" title="{{ 'summary.download_csv' | translate }}" class="btn hide-for-print" [options]="csvOptions"><i class="fa fa-2x fa-file-excel-o"></i></angular2csv>
     <button title="{{ 'summary.download_images' | translate }}" class="btn hide-for-print" (click)="downloadAllGraphsAsImages()"><i class="fa fa-2x fa-file-image-o"></i></button>
-
     <button title="{{ 'summary.download_json' | translate }}" class="btn hide-for-print" (click)="downloadJSON()"><i class="fa fa-2x fa-file-code-o"></i></button>
   </div>
 

--- a/src/app/summary/summary.component.ts
+++ b/src/app/summary/summary.component.ts
@@ -99,7 +99,6 @@ export class SummaryComponent implements OnInit, AfterViewChecked {
    * @private
    */
   async downloadAllGraphsAsImages() {
-    console.log("in downloadAllGraphsAsImages()"); 
     const JSZip = require('jszip');
     const zip = new JSZip();
     this.addImagesToZip(zip).then((zip2: any) => {
@@ -116,9 +115,6 @@ export class SummaryComponent implements OnInit, AfterViewChecked {
     for(let section in this.tempData){
       for(let item in this.tempData[section]){
         for(let question in this.tempData[section][item]){
-          // Questions are labeled with three digits:
-          // Section, Item and Question id
-          // Ex: 124
           if(question.length <= 3){
             this.tempData[section][item]["questions." + question[question.length - 1]] = this.tempData[section][item][question];
             delete this.tempData[section][item][question];
@@ -138,7 +134,6 @@ export class SummaryComponent implements OnInit, AfterViewChecked {
   async downloadJSON() {
     // Copy from the original JSON file (this.allData)
     this.tempData = JSON.parse(JSON.stringify(this.allData));
-
     this.labelJSON();   // Add labels
 
     var fileContents = JSON.stringify(this.tempData);

--- a/src/app/summary/summary.component.ts
+++ b/src/app/summary/summary.component.ts
@@ -35,6 +35,7 @@ export class SummaryComponent implements OnInit, AfterViewChecked {
   content: any[];
   pia: any;
   allData: object;
+  tempData: object;
   dataNav: any;
   displayAllFilters: boolean;
   displayMainPiaData: boolean;
@@ -98,6 +99,7 @@ export class SummaryComponent implements OnInit, AfterViewChecked {
    * @private
    */
   async downloadAllGraphsAsImages() {
+    console.log("in downloadAllGraphsAsImages()"); 
     const JSZip = require('jszip');
     const zip = new JSZip();
     this.addImagesToZip(zip).then((zip2: any) => {
@@ -105,6 +107,53 @@ export class SummaryComponent implements OnInit, AfterViewChecked {
         FileSaver.saveAs(blobContent, 'pia-images.zip');
       });
     });
+  }
+
+  /**
+   * Label the JSON export (make it human readable)
+   */
+  private async labelJSON() {
+    for(let section in this.tempData){
+      for(let item in this.tempData[section]){
+        for(let question in this.tempData[section][item]){
+          // Questions are labeled with three digits:
+          // Section, Item and Question id
+          // Ex: 124
+          if(question.length <= 3){
+            this.tempData[section][item]["questions." + question[question.length - 1]] = this.tempData[section][item][question];
+            delete this.tempData[section][item][question];
+          }
+        }
+        this.tempData[section]["items." + item] = this.tempData[section][item];
+        delete this.tempData[section][item];
+      }
+      this.tempData["sections." + section] = this.tempData[section];
+      delete this.tempData[section];
+    }
+  }
+
+  /**
+   * Download a JSON export
+   */
+  async downloadJSON() {
+    // Copy from the original JSON file (this.allData)
+    this.tempData = JSON.parse(JSON.stringify(this.allData));
+
+    this.labelJSON();   // Add labels
+
+    var fileContents = JSON.stringify(this.tempData);
+    var fileName = "pia-content.json";
+    var fileType = "text/json";
+
+    var a = document.createElement("a");
+    var dataURI = "data:" + fileType + ";base64," + btoa(fileContents);
+    a.href = dataURI;
+    a['download'] = fileName;
+    var e = document.createEvent("MouseEvents");
+    e.initMouseEvent("click", true, true, 
+      document.defaultView, 0, 0, 0, 0, 0,
+      false, false, false, false, 0, null);
+    a.dispatchEvent(e);
   }
 
   /**

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -1335,6 +1335,7 @@
 		},
 		"download_csv": "Download a CSV export",
 		"download_images": "Download images",
+    "download_json": "Download a JSON export",
 		"dpo_name": "DPO's name",
 		"dpo_opinion": "DPO's opinion",
 		"dpo_status": "DPO's status",


### PR DESCRIPTION
Added an extra button on the summary/preview with the functionality of exporting a JSON containing the answers given by the user. The answers are structured in a human readable JSON according to the layout of the PIA (sections, items and questions).

In the TypeScript file for the summary two new functions have been added:
**downloadJSON()** for fetching the data and initiating a download.
**labelJSON()** for adding labels to the original JSON resulting in a human readable structure.
