### PR TITLE
Pre-Slides for Cartography

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+
 # Le logiciel PIA / The PIA Software
 <img src="https://raw.githubusercontent.com/LINCnil/pia/master/src/assets/images/pia-auth-logo.png" align="left" hspace="10" vspace="6"> Le logiciel PIA est un outil distribué librement par la [CNIL](https://www.cnil.fr/fr/outil-pia-telechargez-et-installez-le-logiciel-de-la-cnil) afin de faciliter la réalisation d’analyses d’impact sur la protection des données prévues par le RGPD.
 Version web front office de l’application PIA à déployer sur un serveur afin d’en donner l’accès via un navigateur web. Ce projet est généré avec [Angular CLI](https://github.com/angular/angular-cli). 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-
 # Le logiciel PIA / The PIA Software
 <img src="https://raw.githubusercontent.com/LINCnil/pia/master/src/assets/images/pia-auth-logo.png" align="left" hspace="10" vspace="6"> Le logiciel PIA est un outil distribué librement par la [CNIL](https://www.cnil.fr/fr/outil-pia-telechargez-et-installez-le-logiciel-de-la-cnil) afin de faciliter la réalisation d’analyses d’impact sur la protection des données prévues par le RGPD.
 Version web front office de l’application PIA à déployer sur un serveur afin d’en donner l’accès via un navigateur web. Ce projet est généré avec [Angular CLI](https://github.com/angular/angular-cli). 

--- a/src/app/entry/entry-content/overview-risks/overview-risks.component.ts
+++ b/src/app/entry/entry-content/overview-risks/overview-risks.component.ts
@@ -274,7 +274,8 @@ export class OverviewRisksComponent implements OnInit {
         i++;
         const answerModel = new Answer();
         await answerModel.getByReferenceAndPia(this._piaService.pia.id, question.id);
-        if (answerModel.data && answerModel.data.gauge > 0) {
+        if (answerModel.data && answerModel.data.gauge > 0 &&
+          question.cartography.split('-')[0] !== 'pre') { // Added to skip pre-*
           const value = answerModel.data.gauge;
           const name = this._translateService.instant('overview-risks.' + question.cartography);
           y += 25;

--- a/src/app/entry/entry-content/risks-cartography/risks-cartography.component.html
+++ b/src/app/entry/entry-content/risks-cartography/risks-cartography.component.html
@@ -19,8 +19,10 @@
           <div>{{ 'cartography.maximal' | translate }}</div>
         </div>
         <ul class="pia-cartographyBlock-legend">
+          <li>{{ 'cartography.legend6' | translate }}</li>
           <li>{{ 'cartography.legend1' | translate }}</li>
           <li>{{ 'cartography.legend2' | translate }}</li>
+          <hr>
           <li>{{ 'cartography.legend3' | translate }}</li>
           <li>{{ 'cartography.legend4' | translate }}</li>
           <li>{{ 'cartography.legend5' | translate }}</li>

--- a/src/app/entry/entry-content/risks-cartography/risks-cartography.component.html
+++ b/src/app/entry/entry-content/risks-cartography/risks-cartography.component.html
@@ -22,7 +22,6 @@
           <li>{{ 'cartography.legend6' | translate }}</li>
           <li>{{ 'cartography.legend1' | translate }}</li>
           <li>{{ 'cartography.legend2' | translate }}</li>
-          <hr>
           <li>{{ 'cartography.legend3' | translate }}</li>
           <li>{{ 'cartography.legend4' | translate }}</li>
           <li>{{ 'cartography.legend5' | translate }}</li>

--- a/src/app/entry/entry-content/risks-cartography/risks-cartography.component.ts
+++ b/src/app/entry/entry-content/risks-cartography/risks-cartography.component.ts
@@ -22,6 +22,11 @@ export class RisksCartographyComponent implements OnInit, OnDestroy {
   dataJSON: any;
   risk1Letter;
   risk2Letter;
+  risk3Letter;
+  dotColor1 = '#000000'
+  dotColor2 = '#FD4664'
+  altColor2 = '#C40288'
+  dotColor3 = '#091C6B'
 
   constructor(private http: HttpClient,
               private _appDataService: AppDataService,
@@ -31,9 +36,11 @@ export class RisksCartographyComponent implements OnInit, OnDestroy {
   async ngOnInit() {
     this.risk1Letter = this._translateService.instant('cartography.risk1_access');
     this.risk2Letter = this._translateService.instant('cartography.risk2_modification');
+    this.risk3Letter = this._translateService.instant('cartography.risk3_disappearance');
     this.subscription = this._translateService.onLangChange.subscribe((event: LangChangeEvent) => {
       this.risk1Letter = this._translateService.instant('cartography.risk1_access');
       this.risk2Letter = this._translateService.instant('cartography.risk2_modification');
+      this.risk3Letter = this._translateService.instant('cartography.risk3_disappearance');
       this.loadCartography();
     });
 
@@ -55,14 +62,17 @@ export class RisksCartographyComponent implements OnInit, OnDestroy {
     // JSON data
     this.dataJSON = {
       'risk-access': {
+        'pre': { x: null, y: null },
         'author': { x: null, y: null },
         'evaluator': { x: null, y: null }
       },
       'risk-change': {
+        'pre': { x: null, y: null },
         'author': { x: null, y: null },
         'evaluator': { x: null, y: null }
       },
       'risk-disappearance': {
+        'pre': { x: null, y: null },
         'author': { x: null, y: null },
         'evaluator': { x: null, y: null }
       }
@@ -99,7 +109,15 @@ export class RisksCartographyComponent implements OnInit, OnDestroy {
             } else if (cartographyKey[0] === 'risk-disappearance') {
               pointPosition -= 20;
             }
-            this.dataJSON[cartographyKey[0]]['author'][axeValue] =  pointPosition;
+            if (cartographyKey[0] === 'pre-access') {
+              this.dataJSON['risk-access']['pre'][axeValue] = pointPosition;
+            } else if (cartographyKey[0] === 'pre-change') {
+              this.dataJSON['risk-change']['pre'][axeValue] = pointPosition - 10;
+            } else if (cartographyKey[0] === 'pre-disappearance') {
+              this.dataJSON['risk-disappearance']['pre'][axeValue] = pointPosition - 20;
+            } else {
+              this.dataJSON[cartographyKey[0]]['author'][axeValue] = pointPosition;
+            }
           }
         }
       });
@@ -132,6 +150,144 @@ export class RisksCartographyComponent implements OnInit, OnDestroy {
     this.subscription.unsubscribe();
   }
 
+  drawPreDot(context: any, risk: string) {
+    // Dot1
+    if (this.dataJSON[risk]['pre'].x && 
+        this.dataJSON[risk]['pre'].y && 
+        this.dataJSON[risk]['author'].x && 
+        this.dataJSON[risk]['author'].y) {
+      let diameter = 8;
+      // Is the location the same for Dot1 and Dot2?
+      if (this.dataJSON[risk]['author'].x  === this.dataJSON[risk]['pre'].x &&
+          this.dataJSON[risk]['author'].y  === this.dataJSON[risk]['pre'].y) {
+        diameter = 6;
+        context.globalCompositeOperation = 'destination-over';
+      }
+      // Draw Dot1
+      context.beginPath();
+      context.fillStyle = this.dotColor1;
+      context.arc(this.dataJSON[risk]['pre'].x, 
+                  this.dataJSON[risk]['pre'].y, diameter, 0, Math.PI * 2, true);
+      context.fill(); 
+    } else {
+      if (this.dataJSON[risk]['author'].x &&
+          this.dataJSON[risk]['author'].y &&
+          !this.dataJSON[risk]['pre'].x &&
+          !this.dataJSON[risk]['pre'].y) {
+        context.globalCompositeOperation = 'destination-over';
+        context.beginPath();
+        context.fillStyle = this.dotColor1;
+        // Draw Dot1 where Dot2 is, but smaller
+        context.arc(this.dataJSON[risk]['author'].x,
+                    this.dataJSON[risk]['author'].y, 6, 0, Math.PI * 2, true);
+        context.fill();
+      }
+    }
+  }
+
+  drawRiskDot(context: any, risk: string, riskLetter: any) {
+    // Dot2
+    if (this.dataJSON[risk]['author'].x && this.dataJSON[risk]['author'].y) {
+      context.beginPath();
+      if (localStorage.getItem('increaseContrast') === 'true') {
+        context.fillStyle = this.altColor2;
+      } else {
+        context.fillStyle = this.dotColor2;
+      }
+      context.arc(this.dataJSON[risk]['author'].x,
+                  this.dataJSON[risk]['author'].y, 8, 0, Math.PI * 2, true);
+      context.fill();
+      context.textAlign = 'center';
+      context.font = 'bold 1.1rem Roboto, Times, serif';
+      // Add letter in parentheses under Dot2
+      try {
+        context.fillStyle = '#333';
+        context.fillText(riskLetter,
+                    this.dataJSON[risk]['author'].x,
+                    this.dataJSON[risk]['author'].y + 20);
+      } catch (ex) {}
+    }
+  }
+
+  drawEvalDot(context: any, risk: string, offset: number) {
+    // Dot3
+    if (this.dataJSON[risk]['author'].x &&
+        this.dataJSON[risk]['author'].y &&
+        this.dataJSON[risk]['evaluator'].x &&
+        this.dataJSON[risk]['evaluator'].y) {
+      let diameter = 8;
+      if (this.dataJSON[risk]['evaluator'].x - offset === this.dataJSON[risk]['author'].x &&
+          this.dataJSON[risk]['evaluator'].y - offset === this.dataJSON[risk]['author'].y) {
+        diameter = 10;
+        context.globalCompositeOperation = 'destination-over';
+      }
+      context.beginPath();
+      context.fillStyle = this.dotColor3;
+      context.arc(this.dataJSON[risk]['evaluator'].x - offset, 
+                  this.dataJSON[risk]['evaluator'].y - offset, diameter, 0, Math.PI * 2, true);
+      context.fill(); 
+    } else {
+      if (!this.dataJSON[risk]['evaluator'].x &&
+          !this.dataJSON[risk]['evaluator'].y &&
+          this.dataJSON[risk]['author'].x &&
+          this.dataJSON[risk]['author'].y) {
+        context.globalCompositeOperation = 'destination-over';
+        context.beginPath();
+        context.fillStyle = this.dotColor3;
+        // Draw Dot3 where Dot2 is, but bigger
+        context.arc(this.dataJSON[risk]['author'].x,
+                    this.dataJSON[risk]['author'].y, 10, 0, Math.PI * 2, true);
+        context.fill();
+      }
+    }
+  }
+
+  drawDotLine(context: any, risk: string, offset: number) {
+    // Line from Dot1 to Dot2
+    if (this.dataJSON[risk]['pre'].x && this.dataJSON[risk]['pre'].y &&
+        this.dataJSON[risk]['author'].x && this.dataJSON[risk]['author'].y &&
+        (this.dataJSON[risk]['pre'].x !== this.dataJSON[risk]['author'].x ||
+        this.dataJSON[risk]['pre'].y !== this.dataJSON[risk]['author'].y)) {
+      context.beginPath();
+      const gradRisk1 = context.createLinearGradient(this.dataJSON[risk]['pre'].x,
+                                                    this.dataJSON[risk]['pre'].y,
+                                                    this.dataJSON[risk]['author'].x,
+                                                    this.dataJSON[risk]['author'].y);
+      gradRisk1.addColorStop(0, this.dotColor1);
+      gradRisk1.addColorStop(1, this.dotColor2);
+      context.strokeStyle = gradRisk1;
+      this.canvasArrow(context, 
+                      this.dataJSON[risk]['pre'].x,
+                      this.dataJSON[risk]['pre'].y,
+                      this.dataJSON[risk]['author'].x,
+                      this.dataJSON[risk]['author'].y);
+      context.closePath();
+      context.stroke();
+    } 
+
+    // Line from Dot2 to Dot3
+    if (this.dataJSON[risk]['author'].x && this.dataJSON[risk]['author'].y &&
+        this.dataJSON[risk]['evaluator'].x && this.dataJSON[risk]['evaluator'].y &&
+        (this.dataJSON[risk]['evaluator'].x - offset !== this.dataJSON[risk]['author'].x ||
+        this.dataJSON[risk]['evaluator'].y - offset !== this.dataJSON[risk]['author'].y)) {
+      context.beginPath();
+      const gradRisk2 = context.createLinearGradient(this.dataJSON[risk]['author'].x,
+                                                    this.dataJSON[risk]['author'].y,
+                                                    this.dataJSON[risk]['evaluator'].x,
+                                                    this.dataJSON[risk]['evaluator'].y);
+      gradRisk2.addColorStop(0, this.dotColor2);
+      gradRisk2.addColorStop(1, this.dotColor3);
+      context.strokeStyle = gradRisk2;
+      this.canvasArrow(context, 
+                      this.dataJSON[risk]['author'].x,
+                      this.dataJSON[risk]['author'].y,
+                      this.dataJSON[risk]['evaluator'].x - offset,
+                      this.dataJSON[risk]['evaluator'].y - offset);
+      context.closePath();
+      context.stroke();
+    } 
+  }
+
   /**
    * Loads the risks cartography with author and evalutor choices positioned as dots.
    */
@@ -158,160 +314,20 @@ export class RisksCartographyComponent implements OnInit, OnDestroy {
       context.strokeStyle = 'white';
       context.stroke();
 
-      if (this.dataJSON['risk-access']['author'].x && this.dataJSON['risk-access']['author'].y) {
-        // Author dots (red)
-        context.beginPath();
-        if (localStorage.getItem('increaseContrast') === 'true') {
-          context.fillStyle = '#C40288';
-        } else {
-          context.fillStyle = '#FD4664';
-        }
-        context.arc(this.dataJSON['risk-access']['author'].x + 8,
-                    this.dataJSON['risk-access']['author'].y, 7, 0, Math.PI * 2, true);
-        context.fill();
-        context.textAlign = 'center';
-        context.font = 'bold 1.1rem Roboto, Times, serif';
-        context.fillStyle = '#333';
-        try {
-          context.fillText(this.risk1Letter,
-                      this.dataJSON['risk-access']['author'].x + 8,
-                      this.dataJSON['risk-access']['author'].y + 20);
-        } catch (ex) {}
-      }
+      // Illegitimate access to data: Dot 1, 2 & 3
+      this.drawPreDot(context, 'risk-access');
+      this.drawRiskDot(context, 'risk-access', this.risk1Letter);
+      this.drawEvalDot(context, 'risk-access', 0);
+      
+      // Unwanted modification of data: Dot 1, 2 & 3
+      this.drawPreDot(context, 'risk-change');
+      this.drawRiskDot(context, 'risk-change', this.risk2Letter);
+      this.drawEvalDot(context, 'risk-change', 10);
 
-      if (this.dataJSON['risk-change']['author'].x && this.dataJSON['risk-change']['author'].y) {
-        context.beginPath();
-        if (localStorage.getItem('increaseContrast') === 'true') {
-          context.fillStyle = '#C40288';
-        } else {
-          context.fillStyle = '#FD4664';
-        }
-        context.arc(this.dataJSON['risk-change']['author'].x,
-                    this.dataJSON['risk-change']['author'].y, 7, 0, Math.PI * 2, true);
-        context.fill();
-        context.textAlign = 'center';
-        context.font = 'bold 1.1rem Roboto, Times, serif';
-        context.fillStyle = '#333';
-        try {
-          context.fillText(this.risk2Letter,
-                      this.dataJSON['risk-change']['author'].x,
-                      this.dataJSON['risk-change']['author'].y + 20);
-        } catch (ex) {}
-      }
-
-      if (this.dataJSON['risk-disappearance']['author'].x && this.dataJSON['risk-disappearance']['author'].y) {
-        context.beginPath();
-        if (localStorage.getItem('increaseContrast') === 'true') {
-          context.fillStyle = '#C40288';
-        } else {
-          context.fillStyle = '#FD4664';
-        }
-        context.arc(this.dataJSON['risk-disappearance']['author'].x - 8,
-                    this.dataJSON['risk-disappearance']['author'].y, 7, 0, Math.PI * 2, true);
-        context.fill();
-        context.textAlign = 'center';
-        context.font = 'bold 1.1rem Roboto, Times, serif';
-        context.fillStyle = '#333';
-        try {
-          context.fillText('(D)',
-                          this.dataJSON['risk-disappearance']['author'].x - 8,
-                          this.dataJSON['risk-disappearance']['author'].y + 20);
-        } catch (ex) {}
-      }
-
-      // Evaluator dots (blue)
-      if (this.dataJSON['risk-access']['author'].x &&
-          this.dataJSON['risk-access']['author'].y &&
-          this.dataJSON['risk-access']['evaluator'].x &&
-          this.dataJSON['risk-access']['evaluator'].y) {
-        let diameter = 7;
-        if (this.dataJSON['risk-access']['evaluator'].x === this.dataJSON['risk-access']['author'].x &&
-            this.dataJSON['risk-access']['evaluator'].y === this.dataJSON['risk-access']['author'].y) {
-          diameter = 10;
-          context.globalCompositeOperation = 'destination-over';
-        }
-        context.beginPath();
-        context.fillStyle = '#091C6B';
-        context.arc(this.dataJSON['risk-access']['evaluator'].x + 8,
-                    this.dataJSON['risk-access']['evaluator'].y, diameter, 0, Math.PI * 2, true);
-        context.fill();
-      } else {
-        if (!this.dataJSON['risk-access']['evaluator'].x &&
-            !this.dataJSON['risk-access']['evaluator'].y &&
-            this.dataJSON['risk-access']['author'].x &&
-            this.dataJSON['risk-access']['author'].y) {
-          context.globalCompositeOperation = 'destination-over';
-          context.beginPath();
-          context.fillStyle = '#091C6B';
-          context.arc(this.dataJSON['risk-access']['author'].x + 8,
-                      this.dataJSON['risk-access']['author'].y, 10, 0, Math.PI * 2, true);
-          context.fill();
-        }
-      }
-
-      if (this.dataJSON['risk-change']['author'].x &&
-          this.dataJSON['risk-change']['author'].y &&
-          this.dataJSON['risk-change']['evaluator'].x &&
-          this.dataJSON['risk-change']['evaluator'].y) {
-        let x = this.dataJSON['risk-change']['evaluator'].x;
-        let y = this.dataJSON['risk-change']['evaluator'].y;
-        let diameter = 7;
-        if (this.dataJSON['risk-change']['evaluator'].x - 10 === this.dataJSON['risk-change']['author'].x &&
-            this.dataJSON['risk-change']['evaluator'].y - 10 === this.dataJSON['risk-change']['author'].y) {
-          x = this.dataJSON['risk-change']['evaluator'].x - 10;
-          y = this.dataJSON['risk-change']['evaluator'].y - 10;
-          diameter = 10;
-          context.globalCompositeOperation = 'destination-over';
-        }
-        context.beginPath();
-        context.fillStyle = '#091C6B';
-        context.arc(x, y, diameter, 0, Math.PI * 2, true);
-        context.fill();
-      } else {
-        if (!this.dataJSON['risk-change']['evaluator'].x &&
-            !this.dataJSON['risk-change']['evaluator'].y &&
-            this.dataJSON['risk-change']['author'].x &&
-            this.dataJSON['risk-change']['author'].y) {
-          context.globalCompositeOperation = 'destination-over';
-          context.beginPath();
-          context.fillStyle = '#091C6B';
-          context.arc(this.dataJSON['risk-change']['author'].x,
-                      this.dataJSON['risk-change']['author'].y, 10, 0, Math.PI * 2, true);
-          context.fill();
-        }
-      }
-
-      if (this.dataJSON['risk-disappearance']['author'].x &&
-          this.dataJSON['risk-disappearance']['author'].y &&
-          this.dataJSON['risk-disappearance']['evaluator'].x &&
-          this.dataJSON['risk-disappearance']['evaluator'].y) {
-        let x = this.dataJSON['risk-disappearance']['evaluator'].x;
-        let y = this.dataJSON['risk-disappearance']['evaluator'].y;
-        let diameter = 7;
-        if (this.dataJSON['risk-disappearance']['evaluator'].x - 20 === this.dataJSON['risk-disappearance']['author'].x &&
-            this.dataJSON['risk-disappearance']['evaluator'].y - 20 === this.dataJSON['risk-disappearance']['author'].y) {
-          x = this.dataJSON['risk-disappearance']['evaluator'].x - 28;
-          y = this.dataJSON['risk-disappearance']['evaluator'].y - 20;
-          diameter = 10;
-          context.globalCompositeOperation = 'destination-over';
-        }
-        context.beginPath();
-        context.fillStyle = '#091C6B';
-        context.arc(x, y, diameter, 0, Math.PI * 2, true);
-        context.fill();
-      } else {
-        if (!this.dataJSON['risk-disappearance']['evaluator'].x &&
-            !this.dataJSON['risk-disappearance']['evaluator'].y &&
-            this.dataJSON['risk-disappearance']['author'].x &&
-            this.dataJSON['risk-disappearance']['author'].y) {
-          context.globalCompositeOperation = 'destination-over';
-          context.beginPath();
-          context.fillStyle = '#091C6B';
-          context.arc(this.dataJSON['risk-disappearance']['author'].x - 8,
-                      this.dataJSON['risk-disappearance']['author'].y, 10, 0, Math.PI * 2, true);
-          context.fill();
-        }
-      }
+      // Data disappearance: Dot 1, 2 & 3
+      this.drawPreDot(context, 'risk-disappearance');
+      this.drawRiskDot(context, 'risk-disappearance', this.risk3Letter);
+      this.drawEvalDot(context, 'risk-disappearance', 20);
 
       // Gradient color definition for dotted lines
       const grad = context.createLinearGradient(50, 50, 150, 150);
@@ -320,67 +336,11 @@ export class RisksCartographyComponent implements OnInit, OnDestroy {
       context.setLineDash([3, 2]);
       context.lineWidth = 1;
 
-      // Dotted lines
-      if (this.dataJSON['risk-access']['author'].x && this.dataJSON['risk-access']['author'].y &&
-          this.dataJSON['risk-access']['evaluator'].x && this.dataJSON['risk-access']['evaluator'].y &&
-          (this.dataJSON['risk-access']['evaluator'].x !== this.dataJSON['risk-access']['author'].x ||
-          this.dataJSON['risk-access']['evaluator'].y !== this.dataJSON['risk-access']['author'].y)) {
-        context.beginPath();
-        const gradRisk1 = context.createLinearGradient(this.dataJSON['risk-access']['author'].x,
-                                                      this.dataJSON['risk-access']['author'].y,
-                                                      this.dataJSON['risk-access']['evaluator'].x,
-                                                      this.dataJSON['risk-access']['evaluator'].y);
-        gradRisk1.addColorStop(0, '#FD4664');
-        gradRisk1.addColorStop(1, '#091C6B');
-        context.strokeStyle = gradRisk1;
-        this.canvasArrow(context, this.dataJSON['risk-access']['author'].x + 8,
-                        this.dataJSON['risk-access']['author'].y,
-                        this.dataJSON['risk-access']['evaluator'].x + 8,
-                        this.dataJSON['risk-access']['evaluator'].y);
-        context.closePath();
-        context.stroke();
-      }
-
-      if (this.dataJSON['risk-change']['author'].x && this.dataJSON['risk-change']['author'].y &&
-          this.dataJSON['risk-change']['evaluator'].x && this.dataJSON['risk-change']['evaluator'].y &&
-          (this.dataJSON['risk-change']['evaluator'].x - 10 !== this.dataJSON['risk-change']['author'].x ||
-          this.dataJSON['risk-change']['evaluator'].y - 10 !== this.dataJSON['risk-change']['author'].y)) {
-        context.beginPath();
-        const gradRisk2 = context.createLinearGradient(this.dataJSON['risk-change']['author'].x,
-                                                      this.dataJSON['risk-change']['author'].y,
-                                                      this.dataJSON['risk-change']['evaluator'].x,
-                                                      this.dataJSON['risk-change']['evaluator'].y);
-        gradRisk2.addColorStop(0, '#FD4664');
-        gradRisk2.addColorStop(1, '#091C6B');
-        context.strokeStyle = gradRisk2;
-        this.canvasArrow(context, this.dataJSON['risk-change']['author'].x,
-                        this.dataJSON['risk-change']['author'].y,
-                        this.dataJSON['risk-change']['evaluator'].x,
-                        this.dataJSON['risk-change']['evaluator'].y);
-        context.closePath();
-        context.stroke();
-      }
-
-      if (this.dataJSON['risk-disappearance']['author'].x && this.dataJSON['risk-disappearance']['author'].y &&
-          this.dataJSON['risk-disappearance']['evaluator'].x && this.dataJSON['risk-disappearance']['evaluator'].y &&
-          (this.dataJSON['risk-disappearance']['evaluator'].x - 20 !== this.dataJSON['risk-disappearance']['author'].x ||
-          this.dataJSON['risk-disappearance']['evaluator'].y - 20 !== this.dataJSON['risk-disappearance']['author'].y)) {
-        context.beginPath();
-        const gradRisk3 = context.createLinearGradient(this.dataJSON['risk-disappearance']['author'].x,
-                                                      this.dataJSON['risk-disappearance']['author'].y,
-                                                      this.dataJSON['risk-disappearance']['evaluator'].x,
-                                                      this.dataJSON['risk-disappearance']['evaluator'].y);
-        gradRisk3.addColorStop(0, '#FD4664');
-        gradRisk3.addColorStop(1, '#091C6B');
-        context.strokeStyle = gradRisk3;
-        this.canvasArrow(context, this.dataJSON['risk-disappearance']['author'].x - 8,
-                        this.dataJSON['risk-disappearance']['author'].y,
-                        this.dataJSON['risk-disappearance']['evaluator'].x,
-                        this.dataJSON['risk-disappearance']['evaluator'].y);
-        context.closePath();
-        context.stroke();
-      }
+      this.drawDotLine(context, 'risk-access', 0);
+      this.drawDotLine(context, 'risk-change', 10);
+      this.drawDotLine(context, 'risk-disappearance', 20);
   }
+
 
   /**
    * Draw an arrow between two points.

--- a/src/assets/files/pia_architecture.json
+++ b/src/assets/files/pia_architecture.json
@@ -337,6 +337,34 @@
               "active": true
             },
             {
+              "id": 327,
+              "title": "sections.3.items.2.questions.7.title",
+              "is_measure": true,
+              "link_knowledge_base": [
+                "PIA_DEF_ACCI",
+                "PIA_DEF_MES",
+                "PIA_METHOD_MES"
+              ],
+              "placeholder": "sections.3.items.2.questions.7.placeholder",
+              "answer_type": "gauge",
+              "cartography": "pre-access_x",
+              "active": true
+            },
+            {
+              "id": 328,
+              "title": "sections.3.items.2.questions.8.title",
+              "is_measure": true,
+              "link_knowledge_base": [
+                "PIA_DEF_ACCI",
+                "PIA_DEF_MES",
+                "PIA_METHOD_MES"
+              ],
+              "placeholder": "sections.3.items.2.questions.8.placeholder",
+              "answer_type": "gauge",
+              "cartography": "pre-access_y",
+              "active": true
+            },
+            {
               "id": 324,
               "title": "sections.3.items.2.questions.4.title",
               "is_measure": true,
@@ -431,6 +459,34 @@
               "active": true
             },
             {
+              "id": 337,
+              "title": "sections.3.items.3.questions.7.title",
+              "is_measure": true,
+              "link_knowledge_base": [
+                "PIA_DEF_ACCI",
+                "PIA_DEF_MES",
+                "PIA_METHOD_MES"
+              ],
+              "placeholder": "sections.3.items.3.questions.7.placeholder",
+              "answer_type": "gauge",
+              "cartography": "pre-change_x",
+              "active": true
+            },
+            {
+              "id": 338,
+              "title": "sections.3.items.3.questions.8.title",
+              "is_measure": true,
+              "link_knowledge_base": [
+                "PIA_DEF_ACCI",
+                "PIA_DEF_MES",
+                "PIA_METHOD_MES"
+              ],
+              "placeholder": "sections.3.items.3.questions.8.placeholder",
+              "answer_type": "gauge",
+              "cartography": "pre-change_y",
+              "active": true
+            },
+            {
               "id": 334,
               "title": "sections.3.items.3.questions.4.title",
               "is_measure": true,
@@ -521,6 +577,34 @@
               ],
               "placeholder": "sections.3.items.4.questions.3.placeholder",
               "answer_type": "list",
+              "active": true
+            },
+            {
+              "id": 347,
+              "title": "sections.3.items.4.questions.7.title",
+              "is_measure": true,
+              "link_knowledge_base": [
+                "PIA_DEF_ACCI",
+                "PIA_DEF_MES",
+                "PIA_METHOD_MES"
+              ],
+              "placeholder": "sections.3.items.4.questions.7.placeholder",
+              "answer_type": "gauge",
+              "cartography": "pre-disappearance_x",
+              "active": true
+            },
+            {
+              "id": 348,
+              "title": "sections.3.items.4.questions.8.title",
+              "is_measure": true,
+              "link_knowledge_base": [
+                "PIA_DEF_ACCI",
+                "PIA_DEF_MES",
+                "PIA_METHOD_MES"
+              ],
+              "placeholder": "sections.3.items.4.questions.8.placeholder",
+              "answer_type": "gauge",
+              "cartography": "pre-disappearance_y",
               "active": true
             },
             {

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -37,12 +37,14 @@
 		"legend3": "(I)llegitimate access to data",
 		"legend4": "(U)nwanted modification of data",
 		"legend5": "(D)ata disappearance",
+    "legend6": "Without measures implemented",
 		"likelihood_axe": "Risk likelihood",
 		"limited": "Limited",
 		"maximal": "Maximum",
 		"negligible": "Negligible",
 		"risk1_access": "(I)",
 		"risk2_modification": "(U)",
+    "risk3_disappearance": "(D)",
 		"seriousness_axe": "Risk seriousness"
 	},
 	"comments": {
@@ -1189,6 +1191,14 @@
 						"6": {
 							"placeholder": "Justify here the estimated likelihood.",
 							"title": "How do you estimate the <span class='green-highlight'>likelihood of the risk</span>, especially in respect of threats, sources of risk and planned controls?"
+						},
+						"7": {
+							"placeholder": "Justify here the estimated severity of the risk.",
+							"title": "How do you estimate the <span class='green-highlight'>risk severity</span>, especially according to potential impacts and <span class='green-highlight'>no planned controls</span>?"
+						},
+						"8": {
+							"placeholder": "Justify here the estimated likelihood.",
+							"title": "How do you estimate the <span class='green-highlight'>likelihood of the risk</span>, especially in respect of threats, sources of risk and <span class='green-highlight'>no planned controls</span>?"
 						}
 					},
 					"short_help": "Analyze the causes and consequences of illegitimate access to data, and estimate its severity and likelihood.",
@@ -1219,6 +1229,14 @@
 						"6": {
 							"placeholder": "Justify here the estimated likelihood.",
 							"title": "How do you estimate the <span class='green-highlight'>likelihood of the risk</span>, especially in respect of threats, sources of risk and planned controls?"
+						},
+						"7": {
+							"placeholder": "Justify here the estimated severity of the risk.",
+							"title": "How do you estimate the <span class='green-highlight'>risk severity</span>, especially according to potential impacts and <span class='green-highlight'>no planned controls</span>?"
+						},
+						"8": {
+							"placeholder": "Justify here the estimated likelihood.",
+							"title": "How do you estimate the <span class='green-highlight'>likelihood of the risk</span>, especially in respect of threats, sources of risk and <span class='green-highlight'>no planned controls</span>?"
 						}
 					},
 					"short_help": "Analyze the causes and consequences of an undesired change in data, and estimate its seriousness and likelihood.",
@@ -1249,6 +1267,14 @@
 						"6": {
 							"placeholder": "Justify here the estimated likelihood.",
 							"title": "How do you estimate the <span class='green-highlight'>likelihood of the risk</span>, especially in respect of threats, sources of risk and planned controls?"
+						},
+						"7": {
+							"placeholder": "Justify here the estimated severity of the risk.",
+							"title": "How do you estimate the <span class='green-highlight'>risk severity</span>, especially according to potential impacts and <span class='green-highlight'>no planned controls</span>?"
+						},
+						"8": {
+							"placeholder": "Justify here the estimated likelihood.",
+							"title": "How do you estimate the <span class='green-highlight'>likelihood of the risk</span>, especially in respect of threats, sources of risk and <span class='green-highlight'>no planned controls</span>?"
 						}
 					},
 					"short_help": "Analyze the causes and consequences of data loss, and estimate its seriousness and likelihood.",


### PR DESCRIPTION
Added new slides for the items in Section 3 (Risks). These slides will represent the _risk severity_ and _likelihood of the risk_ **without** any implemented measures.
These slides are added for access, change and disappearance and can be seen on the Risk Mapping in Section 4 (Validation) as black dots.

Some more changes in **risks-cartography.component.ts** :
"risk3Letter" has been implemented properly.
"dotColor1, 2 & 3" can now more easily be changed, being variables.
"pre"-values has been added to risk-access, risk-change & risk-disappearance for the new slides.
The code for drawing the dots and lines have been replaced by less redundant and more reusable functions:
"drawPreDot", "drawRiskDot", "drawEvalDot" & "drawDotLine".

Added the new slides as questions in pia_architecture.json
Added new translations in en.json
