### PR TITLE
fix: empty answer list is sometimes undefined

### DIFF
--- a/src/app/entry/entry-content/questions/answer.model.ts
+++ b/src/app/entry/entry-content/questions/answer.model.ts
@@ -1,8 +1,14 @@
 import { ApplicationDb } from '../../../application.db';
 
+export interface AnswerData {
+  text: string;
+  gauge: number;
+  list: string[];
+}
+
 export class Answer extends ApplicationDb {
   public id: number;
-  public data: { text: string; gauge: number; list: string[] };
+  private _data: AnswerData;
   public answer_type: string;
 
   constructor() {
@@ -86,6 +92,19 @@ export class Answer extends ApplicationDb {
         }
       });
     });
+  }
+
+  get data(): AnswerData {
+    return this._data;
+  }
+
+  set data(data: AnswerData) {
+    this._data = data;
+    // When sending a PATCH, JSON arrays are not sent.
+    // Because of this, the resulting data.list might be set to undefined.
+    if (data.list == null) {
+      this._data.list = [];
+    }
   }
 
   private setFormData(data) {


### PR DESCRIPTION
Fixes #518 
When using pia-back, the PATCH request does not work properly when `answer.data.list` is empty. Because there are no items, the content of the request does not mention `answer.data.list` at all. Because of this, data.list is not saved in the database (only `data.text` and `data.gauge`).

Because of this, when retrieving `anwer.data` afterwards, `answer.data.list` is undefined and makes the client throw errors in multiple places, saying `answer.data.list` is undefined.

I chose to fix this client-side here for two reasons :
- This fix does not require to repair the data in the database if invalid data was already there before the fix was deployed.
- It's easier for me because I don't know Ruby. 😄 