### PR TITLE
🐛 Fix `yarn prod` for current Angular version

### DIFF
--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -1,4 +1,4 @@
-import * as packageJson from '../../package.json';
+import packageJson from '../../package.json';
 export const environment = {
   name: 'production',
   production: true,


### PR DESCRIPTION
It seems that since the project updated to a newer version of Angular, the
production build doesn't work anymore. I tracked the issue down to the
`src/environments/environment.prod.ts` file, which wasn't updated to match the
`src/environments/environment.ts` file.

Before the fix, `yarn prod` fails with this error:

```
./src/environments/environment.ts:5:11-30 - Error: Should not import the named export 'version' (imported as 'packageJson') from default-exporting module (only default export is available soon)
```

After the fix, `yarn prod` succeeds.
