### PR TITLE
fix: adjust gauge input enable/disable logic

### DIFF
--- a/src/app/modules/pia/content/questions/questions.component.html
+++ b/src/app/modules/pia/content/questions/questions.component.html
@@ -23,12 +23,6 @@
         <input
           type="range"
           (change)="checkGaugeChanges($event)"
-          [attr.disabled]="
-            (!editMode.includes('author') && editMode !== 'local') ||
-            !globalEvaluationService.answerEditionEnabled
-              ? 'true'
-              : null
-          "
           formControlName="gauge"
           min="0"
           max="4"

--- a/src/app/modules/pia/content/questions/questions.component.ts
+++ b/src/app/modules/pia/content/questions/questions.component.ts
@@ -80,10 +80,17 @@ export class QuestionsComponent implements OnInit, OnDestroy {
           this.questionForm.controls['gauge'].setValue(this.answer.data.gauge, {
             emitEvent: false
           });
-          this.questionForm.controls['gauge'].disable({
-            onlySelf: true,
-            emitEvent: false
-          });
+          if (this.isInputDisabled()) {
+            this.questionForm.controls['gauge'].disable({
+              onlySelf: true,
+              emitEvent: false
+            });
+          } else {
+            this.questionForm.controls['gauge'].enable({
+              onlySelf: true,
+              emitEvent: false
+            });
+          }
           this.questionForm.controls['text'].patchValue(this.answer.data.text);
           if (this.answer.data.list) {
             const dataList = this.answer.data.list.filter(l => {


### PR DESCRIPTION
This pull request refactors how the "gauge" input is enabled or disabled in the `QuestionsComponent`. The logic for disabling the input is moved from the template to the TypeScript code, improving maintainability and clarity.

Form control state management:

* The disabling logic for the `gauge` input is now handled programmatically in the component's TypeScript file using the `isInputDisabled()` method, instead of using a complex conditional in the template. (`src/app/modules/pia/content/questions/questions.component.ts`)
* The `[attr.disabled]` binding with a multi-condition expression has been removed from the template, simplifying the HTML and delegating control state to the component logic. (`src/app/modules/pia/content/questions/questions.component.html`)