### PR TITLE
fix: encoding for TinyMCE editor

### DIFF
--- a/src/app/modules/pia/content/evaluations/evaluations.component.ts
+++ b/src/app/modules/pia/content/evaluations/evaluations.component.ts
@@ -478,6 +478,7 @@ export class EvaluationsComponent
       suffix: '.min',
       branding: false,
       menubar: false,
+      entity_encoding: 'raw',
       statusbar: false,
       plugins: 'autoresize lists',
       autoresize_bottom_margin: 30,

--- a/src/app/modules/structure/content/measures/measures.component.ts
+++ b/src/app/modules/structure/content/measures/measures.component.ts
@@ -238,6 +238,7 @@ export class MeasuresComponent implements OnInit, OnDestroy {
       suffix: '.min',
       branding: false,
       menubar: false,
+      entity_encoding: 'raw',
       statusbar: false,
       plugins: 'autoresize lists',
       autoresize_bottom_margin: 30,

--- a/src/app/modules/structure/content/questions/questions.component.ts
+++ b/src/app/modules/structure/content/questions/questions.component.ts
@@ -218,6 +218,7 @@ export class QuestionsComponent implements OnInit, OnDestroy {
       suffix: '.min',
       branding: false,
       menubar: false,
+      entity_encoding: 'raw',
       statusbar: false,
       plugins: 'autoresize lists',
       autoresize_bottom_margin: 30,


### PR DESCRIPTION
To make sure that exported PDF contains real chars and not HTML entities names.