### PR TITLE
fix: make textarea visible before TinyMCE init on edit

### DIFF
--- a/src/app/modules/pia/content/measures/measures.component.ts
+++ b/src/app/modules/pia/content/measures/measures.component.ts
@@ -229,7 +229,6 @@ export class MeasuresComponent implements OnInit, OnDestroy {
    */
   measureContentFocusIn(): void {
     if (this.globalEvaluationService.answerEditionEnabled) {
-      // FIX: rendre la textarea visible AVANT l'init TinyMCE.
       this.hideTextarea = false;
       setTimeout(() => this.loadEditor(), 0);
     }

--- a/src/app/modules/pia/content/measures/measures.component.ts
+++ b/src/app/modules/pia/content/measures/measures.component.ts
@@ -229,7 +229,9 @@ export class MeasuresComponent implements OnInit, OnDestroy {
    */
   measureContentFocusIn(): void {
     if (this.globalEvaluationService.answerEditionEnabled) {
-      this.loadEditor();
+      // FIX: rendre la textarea visible AVANT l'init TinyMCE.
+      this.hideTextarea = false;
+      setTimeout(() => this.loadEditor(), 0);
     }
   }
 

--- a/src/app/modules/pia/content/questions/questions.component.ts
+++ b/src/app/modules/pia/content/questions/questions.component.ts
@@ -272,7 +272,9 @@ export class QuestionsComponent implements OnInit, OnDestroy {
    */
   questionContentFocusIn(): void {
     if (this.globalEvaluationService.answerEditionEnabled) {
-      this.loadEditor();
+      // FIX: rendre la textarea visible AVANT l'init TinyMCE.
+      this.hideTextarea = false;
+      setTimeout(() => this.loadEditor(), 0);
     }
   }
 

--- a/src/app/modules/pia/content/questions/questions.component.ts
+++ b/src/app/modules/pia/content/questions/questions.component.ts
@@ -272,7 +272,6 @@ export class QuestionsComponent implements OnInit, OnDestroy {
    */
   questionContentFocusIn(): void {
     if (this.globalEvaluationService.answerEditionEnabled) {
-      // FIX: rendre la textarea visible AVANT l'init TinyMCE.
       this.hideTextarea = false;
       setTimeout(() => this.loadEditor(), 0);
     }

--- a/src/app/modules/structure/content/measures/measures.component.ts
+++ b/src/app/modules/structure/content/measures/measures.component.ts
@@ -154,7 +154,9 @@ export class MeasuresComponent implements OnInit, OnDestroy {
     if (this.structure.is_example) {
       return;
     }
-    this.loadEditor();
+    // FIX: rendre la textarea visible AVANT l'init TinyMCE (cf. questions.component.ts).
+    this.hideTextarea = false;
+    setTimeout(() => this.loadEditor(), 0);
   }
 
   /**

--- a/src/app/modules/structure/content/measures/measures.component.ts
+++ b/src/app/modules/structure/content/measures/measures.component.ts
@@ -154,7 +154,6 @@ export class MeasuresComponent implements OnInit, OnDestroy {
     if (this.structure.is_example) {
       return;
     }
-    // FIX: rendre la textarea visible AVANT l'init TinyMCE (cf. questions.component.ts).
     this.hideTextarea = false;
     setTimeout(() => this.loadEditor(), 0);
   }

--- a/src/app/modules/structure/content/questions/questions.component.ts
+++ b/src/app/modules/structure/content/questions/questions.component.ts
@@ -168,9 +168,6 @@ export class QuestionsComponent implements OnInit, OnDestroy {
       questionTitleTextarea.classList.add('pia-required');
       questionTitleTextarea.focus();
     } else if (this.globalEvaluationService.answerEditionEnabled) {
-      // FIX: rendre la textarea visible AVANT l'init TinyMCE.
-      // TinyMCE 8 + autoresize echoue silencieusement si l'element cible
-      // est en display:none, ce qui se produit quand answer.length > 0.
       this.hideTextarea = false;
       setTimeout(() => this.loadEditor(), 0);
     }

--- a/src/app/modules/structure/content/questions/questions.component.ts
+++ b/src/app/modules/structure/content/questions/questions.component.ts
@@ -168,7 +168,11 @@ export class QuestionsComponent implements OnInit, OnDestroy {
       questionTitleTextarea.classList.add('pia-required');
       questionTitleTextarea.focus();
     } else if (this.globalEvaluationService.answerEditionEnabled) {
-      this.loadEditor();
+      // FIX: rendre la textarea visible AVANT l'init TinyMCE.
+      // TinyMCE 8 + autoresize echoue silencieusement si l'element cible
+      // est en display:none, ce qui se produit quand answer.length > 0.
+      this.hideTextarea = false;
+      setTimeout(() => this.loadEditor(), 0);
     }
   }
 


### PR DESCRIPTION
## Problem

When clicking on the body of a question or measure that already has content (`answer.length > 0`), the editor opens visually empty: the rendered `<div>` is hidden (because `editor` becomes truthy) **and** the TinyMCE iframe stays invisible.

Result: the user thinks their content has been wiped, even though the data is preserved in IndexedDB.

This happens **every time** an imported structure or PIA is edited — every answer is pre-filled at import, so every textarea has `hideTextarea = true`.

## Root cause

In `ngOnInit`, the component sets:
```ts
this.hideTextarea = this.question.answer?.length > 0;
```

The textarea then has the `.hide` CSS class, which is `display: none !important` in `styles.scss`.

When the user clicks to edit, `loadEditor()` calls `tinymce.init({ selector: '#' + elementId })` on a textarea that is `display: none`. **TinyMCE 8 + the `autoresize` plugin fails silently in this case**: the iframe is created but its height stays at 0 because layout calculations on a hidden ancestor return 0.

The user sees nothing — and clicking elsewhere triggers `focusout`, which writes the (empty) editor content back to the form, although in practice the existing answer is preserved on next display because `getContent()` returns whatever the editor parsed at init.

## Fix

In `questionContentFocusIn` and `measureContentFocusIn`, set `hideTextarea = false` so the textarea is visible **before** TinyMCE attaches, and defer `loadEditor()` to the next macrotask so Angular has time to apply the class change to the DOM:

```ts
this.hideTextarea = false;
setTimeout(() => this.loadEditor(), 0);
```

## Scope

Applied to all 4 components that use the same pattern:
- `src/app/modules/structure/content/questions/questions.component.ts`
- `src/app/modules/structure/content/measures/measures.component.ts`
- `src/app/modules/pia/content/questions/questions.component.ts`
- `src/app/modules/pia/content/measures/measures.component.ts`

Total: **+10 / -2 lines**.

## How to reproduce (before the fix)

1. Import any structure or PIA that has answers.
2. Click on the body of a question with content.
3. The section appears to collapse / wipe — the editor doesn't show.

## After the fix

The textarea becomes visible before TinyMCE initializes; the editor renders correctly with the existing content.